### PR TITLE
implement subgame resolution

### DIFF
--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -166,15 +166,8 @@ const Game = () => {
                       overlay={<Tooltip>{winner.opposesRoot ? 'Attacker of Root Claim' : 'Defender of Root Claim'}</Tooltip>}
                       placement="top"
                     >
-                      <span>{winner.opposesRoot ? '🔪' : '🛡️'}</span>
+                      <span>{winner.opposesRoot ? '🔪 Challengers Win' : '🛡️ Defenders Win'}</span>
                     </OverlayTrigger>
-                    {' '}
-                    Claim # {winner.index + 1}
-                    {' | '}
-                    <CopyCode
-                      code={`${data.claims[winner.index].claim.slice(0, 8)}..${data.claims[winner.index].claim.slice(58, 64)}`}
-                      toCopy={data.claims[winner.index].claim}
-                    />
                   </>
                 )}
               </Box>


### PR DESCRIPTION
Swaps the old leftmost-based resolution rule with subgame resolution. The "Current Winner" now displays the winning team, rather than the winning leftmost claim, as there isn't any single winner in subgame-based resolution.

![image](https://github.com/clabby/dispute-viz/assets/3516807/859a027b-6b23-464a-aafb-138ff9bb836b)
